### PR TITLE
Allow FDW extensions to support MERGE command via CustomScan

### DIFF
--- a/doc/src/sgml/fdwhandler.sgml
+++ b/doc/src/sgml/fdwhandler.sgml
@@ -1288,6 +1288,31 @@ RecheckForeignScan(ForeignScanState *node,
     </para>
    </sect2>
 
+   <sect2 id="fdw-callbacks-merge">
+    <title>FDW Routines for <command>MERGE</command></title>
+
+    <para>
+<programlisting>
+bool
+IsForeignServerMergeCapable();
+</programlisting>
+
+     Postgres doesn't support <command>MERGE</command> on foreign tables,
+     see <function>ExecMerge</function>. Still, extensions may provide
+     custom scan nodes to support <command>MERGE</command> on foreign
+     tables. If your extension provides such custom scan node, this
+     function should return true.
+    </para>
+
+    <para>
+     If the <function>IsForeignServerMergeCapable</function> pointer is set to
+     <literal>NULL</literal> or returns <literal>false</literal>,
+     <command>MERGE</command> fails on the planning phase with a proper
+     error message.
+    </para>
+
+   </sect2>
+
    <sect2 id="fdw-callbacks-explain">
     <title>FDW Routines for <command>EXPLAIN</command></title>
 

--- a/src/backend/optimizer/plan/createplan.c
+++ b/src/backend/optimizer/plan/createplan.c
@@ -7242,13 +7242,17 @@ make_modifytable(PlannerInfo *root, Plan *subplan,
 		 */
 		if (operation == CMD_MERGE && fdwroutine != NULL)
 		{
-			RangeTblEntry *rte = planner_rt_fetch(rti, root);
+			/* Check if the foreign table is mergeable */
+			if (!fdwroutine->IsForeignServerMergeCapable || !fdwroutine->IsForeignServerMergeCapable())
+			{
+				RangeTblEntry *rte = planner_rt_fetch(rti, root);
 
-			ereport(ERROR,
-					errcode(ERRCODE_FEATURE_NOT_SUPPORTED),
-					errmsg("cannot execute MERGE on relation \"%s\"",
-						   get_rel_name(rte->relid)),
-					errdetail_relkind_not_supported(rte->relkind));
+				ereport(ERROR,
+						errcode(ERRCODE_FEATURE_NOT_SUPPORTED),
+						errmsg("cannot execute MERGE on relation \"%s\"",
+							   get_rel_name(rte->relid)),
+						errdetail_relkind_not_supported(rte->relkind));
+			}
 		}
 
 		/*

--- a/src/backend/parser/parse_merge.c
+++ b/src/backend/parser/parse_merge.c
@@ -194,10 +194,18 @@ transformMergeStmt(ParseState *pstate, MergeStmt *stmt)
 										 false, targetPerms);
 	qry->mergeTargetRelation = qry->resultRelation;
 
-	/* The target relation must be a table or a view */
+	/*
+	 * The target relation must be a table or a view.
+	 *
+	 * Although the Merge command on foreign tables are allowed in the
+	 * grammar, it is not natively supported for foreign tables. We allow the
+	 * parser so that we give extensions a chance to support it via custom
+	 * scan nodes.
+	 */
 	if (pstate->p_target_relation->rd_rel->relkind != RELKIND_RELATION &&
 		pstate->p_target_relation->rd_rel->relkind != RELKIND_PARTITIONED_TABLE &&
-		pstate->p_target_relation->rd_rel->relkind != RELKIND_VIEW)
+		pstate->p_target_relation->rd_rel->relkind != RELKIND_VIEW &&
+		pstate->p_target_relation->rd_rel->relkind != RELKIND_FOREIGN_TABLE)
 		ereport(ERROR,
 				(errcode(ERRCODE_FEATURE_NOT_SUPPORTED),
 				 errmsg("cannot execute MERGE on relation \"%s\"",

--- a/src/include/foreign/fdwapi.h
+++ b/src/include/foreign/fdwapi.h
@@ -115,6 +115,8 @@ typedef void (*EndForeignInsert_function) (EState *estate,
 
 typedef int (*IsForeignRelUpdatable_function) (Relation rel);
 
+typedef bool (*IsForeignServerMergeCapable_function) (void);
+
 typedef bool (*PlanDirectModify_function) (PlannerInfo *root,
 										   ModifyTable *plan,
 										   Index resultRelation,
@@ -247,6 +249,9 @@ typedef struct FdwRoutine
 	GetForeignRowMarkType_function GetForeignRowMarkType;
 	RefetchForeignRow_function RefetchForeignRow;
 	RecheckForeignScan_function RecheckForeignScan;
+
+	/* Support functions for MERGE */
+	IsForeignServerMergeCapable_function IsForeignServerMergeCapable;
 
 	/* Support functions for EXPLAIN */
 	ExplainForeignScan_function ExplainForeignScan;

--- a/src/tools/pgindent/typedefs.list
+++ b/src/tools/pgindent/typedefs.list
@@ -1268,6 +1268,7 @@ IpcSemaphoreId
 IpcSemaphoreKey
 IsForeignPathAsyncCapable_function
 IsForeignRelUpdatable_function
+IsForeignServerMergeCapable_function
 IsForeignScanParallelSafe_function
 IsoConnInfo
 IspellDict


### PR DESCRIPTION
Currently, it is not possible for any fdw extension to support Merge command, as that's prohibited in the parser.

In this commit, we allow extensions to support Merge command via `CustomScan` node by moving the Merge support check from parser to planner.

For existing fdw, they don't have to change anyting. We change postgres_fdw mostly for documentation purposes.